### PR TITLE
Copy editing: CCD Reduction Guide notebook 01-11

### DIFF
--- a/notebooks/01-11-reading-images.ipynb
+++ b/notebooks/01-11-reading-images.ipynb
@@ -33,7 +33,7 @@
     "both to store the fake images we generate and to read images. In normal use, you\n",
     "wouldn't start by writing images there, however.\n",
     "\n",
-    "If the images are in the same directory as the notebook you can omit this, or\n",
+    "If the images are in the same directory as the notebook, you can omit this or\n",
     "set it to an empty string `''`. Having images in the same directory as the\n",
     "notebook is less complicated, but it's not at all uncommon to need to work with\n",
     "images in a different directory.\n",
@@ -306,7 +306,7 @@
    "source": [
     "### Filtering and iterating over images\n",
     "\n",
-    "The convenient thing about `ImageFileCollection` is that it provides easy ways\n",
+    "The great thing about `ImageFileCollection` is that it provides convenient ways\n",
     "to filter or loop over files via FITS header keyword values.\n",
     "\n",
     "For example, looping over just the flat files is one line of code:"


### PR DESCRIPTION
This is to copy edit the CCD Reduction Guide. The notebooks have been copy edited according to our more relaxed style for guides and tutorials as noted in the [Astropy Style Guide](http://docs.astropy.org/en/stable/development/style-guide.html#a-note-about-style-and-tone), which allows for sentence case headings and contractions.

@mwcraig I thought I would cluster each section of notebooks (01, 02, 03, etc.) into separate pull requests so they wouldn't get unwieldy, let me know if that works for you. Also, here I started with notebook 01-11 because I had already copy edited notebooks 00-00 through 01-09 last year in PR https://github.com/mwcraig/ccd-reduction-and-photometry-guide/pull/5. But if you've changed any content in those since last year and would like me to read through them again just let me know!