### PR TITLE
Copy editing: CCD Reduction Guide notebooks 02-00 to 02-04

### DIFF
--- a/notebooks/02-00-Handling-overscan-trimming-and-bias-subtraction.ipynb
+++ b/notebooks/02-00-Handling-overscan-trimming-and-bias-subtraction.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "source": [
     "The bias in a CCD camera is a DC offset applied to all pixels so that when the\n",
-    "voltage in each pixel is converted to a number the number will always be\n",
+    "voltage in each pixel is converted to a number, the number will always be\n",
     "positive. In an ideal CCD the bias would be the same for every pixel and not\n",
     "change over time. In practice, the bias is slightly different for each pixel,\n",
     "and can vary by a count or two from night to night or during a night.\n",
@@ -129,7 +129,7 @@
     "+ There is noticeable \"static\" in the images; that is read noise.\n",
     "+ None of the variations are particularly large.\n",
     "+ Combining several bias images vastly reduces the read noise. This example is a\n",
-    "little unrealistic in that 100 bias images were combined but does illustrate the\n",
+    "little unrealistic in that 100 bias images were combined, but it still illustrates the\n",
     "idea that combining images reduces noise."
    ]
   },
@@ -143,7 +143,7 @@
     "taking and combining several calibration images is to reduce the noise if the\n",
     "images are used for calibration. The difference between a single image and a\n",
     "combination of images is apparent in the images above. Another way to see the\n",
-    "impact of combining images in the histogram of pixel values. Notice that the\n",
+    "impact of combining images is in the histogram of pixel values. Notice that the\n",
     "distribution of values is much narrower for the combined image than for a single\n",
     "bias. Pixels near the edges, where the amplifier glow is large, are binned\n",
     "separately from the rest of the pixels to emphasize the uniformity of the chip\n",

--- a/notebooks/02-01-Calibrating-bias-images.ipynb
+++ b/notebooks/02-01-Calibrating-bias-images.ipynb
@@ -11,12 +11,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The purpose of calibrating bias images is three-fold:\n",
+    "The purpose of calibrating bias images is threefold:\n",
     "\n",
     "+ Subtract overscan if you have decided your science will be better if you\n",
     "subtract overscan. See [this discussion of overscan](01-08-Overscan.ipynb) for some guidance.\n",
     "+ Trim the overscan region off of the image if it is present, regardless of\n",
-    "whether you have chosen to subtract the overscan.\n",
+    "whether or not you have chosen to subtract the overscan.\n",
     "+ Combine the bias images into a \"combined\" bias to be used in calibrating the\n",
     "rest of the images. The purpose of combining several images is to reduce as much\n",
     "as possible the read noise in the combined bias.\n",
@@ -80,8 +80,7 @@
    "metadata": {},
    "source": [
     "### Decide where to put your Example 1 calibrated images\n",
-    "Though it is possible to overwrite your raw data with calibrated images that is\n",
-    "a bad idea. Here we create a folder called `example1-reduced` that will contain\n",
+    "Though it is possible to overwrite your raw data with calibrated images, this is not recommended. Here we create a folder called `example1-reduced` that will contain\n",
     "the calibrated data and create it if it doesn't exist."
    ]
   },
@@ -143,8 +142,8 @@
    "metadata": {},
    "source": [
     "Please see the discussion of this camera in\n",
-    "[the overscan notebook](01.08-Overscan.ipynb#Case-1:-Cryogenically-cooled-Large-Format-Camera-(LFC)-at-Palomar) for the appropriate overscan region\n",
-    "to use for this camera. Note, in particular, that it differs from the the value\n",
+    "[the Overscan notebook](01.08-Overscan.ipynb#Case-1:-Cryogenically-cooled-Large-Format-Camera-(LFC)-at-Palomar) for the appropriate overscan region\n",
+    "to use for this camera. Note, in particular, that it differs from the value\n",
     "given in the `BIASSEC` keyword in the header of the images."
    ]
   },
@@ -158,14 +157,14 @@
     "+ `subtract_overscan` for subtracting the overscan from the image, and\n",
     "+ `trim_image` for trimming off the overscan.\n",
     "\n",
-    "First, let's see what the values of `BIASSEC` which sometimes (but not always)\n",
-    "indicates that there is is overscan and which part of the chip is the overscan,\n",
-    "and `CCDSEC`, which is sometimes, but not always present, and indicates which\n",
+    "First, let's see the values of `BIASSEC`, which sometimes (but do not always)\n",
+    "indicate that there is is overscan and which part of the chip is the overscan,\n",
+    "as well as the values of `CCDSEC`, which is sometimes but not always present, and indicates which\n",
     "part of the chip light hit.\n",
     "\n",
     "Note that neither of these are standard; sometimes, for example, `trimsec` is\n",
     "used instead of `ccdsec`, and there are likely other variants. Some images may\n",
-    "have neither keyword in the header. That does not necessary indicate that\n",
+    "have neither keyword in the header. This does not necessarily indicate that\n",
     "ovserscan isn't present. The best advice is to carefully check the documentation\n",
     "for the camera you are using."
    ]
@@ -193,21 +192,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### FITS *vs* Python indexing\n",
+    "### FITS vs. Python indexing\n",
     "\n",
     "There are two differences between FITS and Python in terms of indexing:\n",
     "\n",
-    "+ Python indexes are zero-based (i.e. numbering starts at zero), FITS indexes\n",
-    "are one-based (i.e. numbering starts at 1).\n",
+    "+ Python indexes are zero-based (i.e., numbering starts at zero), while FITS indexes\n",
+    "are one-based (i.e., numbering starts at one).\n",
     "+ The *order* of the indexes is swapped.\n",
     "\n",
     "For example, the **FITS** representation of the part of the chip exposed to\n",
-    "light is `[1:2048,1:4128]`. To access that part of the data from a numpy array\n",
+    "light is `[1:2048,1:4128]`. To access that part of the data from a NumPy array\n",
     "in **Python**, switch the order so that the indexing looks like this: `[0:4128,\n",
     "0:2048]` (or, more compactly `[:, :2048]`). Note that the *ending* indexes given\n",
-    "here for python are correct because the second part of a range (after the colon)\n",
+    "here for Python are correct because the second part of a range (after the colon)\n",
     "is *not included* in the array slice. For example, `0:2048` starts at 0 (the\n",
-    "first pixel) and goes up to but not including 2048, so the last pixel included\n",
+    "first pixel) and goes up to but does not include 2048, so the last pixel included\n",
     "is `2047` (the 2048$^{th}$ pixel)."
    ]
   },
@@ -215,16 +214,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As discussed in [the overscan notebook](01.08-Overscan.ipynb#Case-1:-Cryogenically-cooled-Large-Format-Camera-(LFC)-at-Palomar), the useful\n",
+    "As discussed in [the Overscan notebook](01.08-Overscan.ipynb#Case-1:-Cryogenically-cooled-Large-Format-Camera-(LFC)-at-Palomar), the useful\n",
     "overscan region for this camera starts at the 2055$^{th}$ column, not column\n",
     "2049 as indicated by the `BIASSEC` keyword in the header. This situation is not\n",
-    "unusual; column 2049 is the first of the columns masked by the manufacturer from\n",
-    "light but there is some leakage into this region from the rest of the CCD.\n",
+    "unusual; column 2049 is the first of the columns masked from light by the manufacturer, \n",
+    "but there is some leakage into this region from the rest of the CCD.\n",
     "\n",
-    "If you are going to overscan you need to carefully examine the overscan in a few\n",
+    "If you are going to use overscan you need to carefully examine the overscan in a few\n",
     "representative images to understand which part of the overscan to use.\n",
     "\n",
-    "In what follows, we will use for the overscan the region (Python/numpy indexing)\n",
+    "In what follows, we will use for the overscan the region (Python/NumPy indexing)\n",
     "`[:, 2055:]`."
    ]
   },
@@ -239,7 +238,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using `subtract_overscan` is reasonably straightforward, as shown in the cell\n",
+    "Using `subtract_overscan` is reasonably concise, as shown in the cell\n",
     "below."
    ]
   },
@@ -275,7 +274,7 @@
    "metadata": {},
    "source": [
     "Next, we trim off the full overscan region (not just the part we used for\n",
-    "subtracting overscan)"
+    "subtracting overscan)."
    ]
   },
   {
@@ -312,15 +311,15 @@
     "from subtracting the same value from each pixel in an image. It simply shifts\n",
     "the zero point.\n",
     "\n",
-    "There is ones other important difference between the images: the input image\n",
+    "There is one other important difference between the images: the input image\n",
     "uses 32MB of memory while the calibrated, overscan-subtracted image uses roughly\n",
     "128MB. The input image is stored as unsigned 16-bit integers; the calibrated\n",
-    "image is stored as floating point numbers, which default in python to 64-bit\n",
+    "image is stored as floating point numbers, which default in Python to 64-bit\n",
     "floats. The memory size is also the size the files will have when written to\n",
-    "disk (ignoring any compression). One can reduce the memory and disk footprint by\n",
+    "disk (ignoring any compression). You can reduce the memory and disk footprint by\n",
     "changing the `dtype` of the image: `trimmed_bias.dtype = 'float32'`. It is best\n",
     "to do this just before writing the image out because arithmetic operations on\n",
-    "the image may convert its dtype back to `float64`.\n",
+    "the image may convert its `dtype` back to `float64`.\n",
     "\n"
    ]
   },
@@ -338,7 +337,7 @@
     "Processing each of the bias images individually would be tedious, at best.\n",
     "Instead, we can use the [`ImageFileCollection`](https://ccdproc.readthedocs.io/en/latest/ccdproc/image_management.html) we created above to\n",
     "loop over only the bias images, saving each in the folder `calibrated_data`. In\n",
-    "this example the files are saved uncompressed because the Python library for\n",
+    "this example, the files are saved uncompressed because the Python library for\n",
     "compressing gzip files is extremely slow."
    ]
   },
@@ -410,8 +409,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Though it is possible to overwrite your raw data with calibrated images that is\n",
-    "a bad idea. Here we create a folder called `example2-reduced` that will contain\n",
+    "Though it is possible to overwrite your raw data with calibrated images, this is not recommended. Here we create a folder called `example2-reduced` that will contain\n",
     "the calibrated data and create it if it doesn't exist."
    ]
   },
@@ -446,7 +444,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Please see the discussion of this camera in [the overscan notebook](01.08-Overscan.ipynb#Case-2:-Thermo-electrically-cooled-Apogee-Aspen-CG16M) for\n",
+    "Please see the discussion of this camera in [the Overscan notebook](01.08-Overscan.ipynb#Case-2:-Thermo-electrically-cooled-Apogee-Aspen-CG16M) for\n",
     "a discussion of the overscan region of this camera. The overscan for this camera\n",
     "is not useful but should be trimmed out at this stage.\n",
     "\n",
@@ -470,7 +468,7 @@
    "source": [
     "Based on this, and the decision not to subtract overscan for this camera, we\n",
     "will only need to trim the overscan region off of the images. See the discussion\n",
-    "at [FITS *vs* Python indexing](#FITS-vs-Python-indexing), above, for some details about the\n",
+    "at [FITS vs. Python indexing](#FITS-vs-Python-indexing), above, for some details about the\n",
     "difference between FITS and Python indexing. Essentially, to get Python indexes\n",
     "from FITS, reverse the order and subtract one."
    ]
@@ -502,7 +500,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There two ways of specifying the region to trim. One is to slice the image in\n",
+    "There are two ways of specifying the region to trim. One is to slice the image in\n",
     "Python; the other is to use the `fits_section` argument to `trim_image`.\n",
     "\n",
     "The cell below uses a FITS-style section."

--- a/notebooks/02-04-Combine-bias-images-to-make-master.ipynb
+++ b/notebooks/02-04-Combine-bias-images-to-make-master.ipynb
@@ -17,7 +17,7 @@
     "subtracted.\n",
     "\n",
     "Regardless of which path you took through the calibration of the biases (with\n",
-    "overscan or without) there should be a folder named `reduced` that contains the\n",
+    "overscan or without), there should be a folder named `reduced` that contains the\n",
     "calibrated bias images. If there is not, please run the previous notebook before\n",
     "continuing with this one."
    ]
@@ -66,11 +66,11 @@
     "+ An object-oriented interface built around the `Combiner` object, described in\n",
     "the [ccdproc documentation on image combination]().\n",
     "+ A function called `combine`, which we will use here because the function\n",
-    "allows one to specify the maximum amount of memory that should be used during\n",
-    "combination. That feature can be essential depending on how many images you need\n",
+    "allows you to specify the maximum amount of memory that should be used during\n",
+    "combination. This feature can be essential depending on how many images you need\n",
     "to combine, how big they are, and how much memory your computer has.\n",
     "\n",
-    "*NOTE: If using a version of ccdproc lower than 2.0 set the memory limit a\n",
+    "*NOTE: If using a version of ccdproc lower than 2.0, set the memory limit a\n",
     "factor of 2-3 lower than you want the maximum memory consumption to be.*"
    ]
   },
@@ -78,7 +78,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 1: cryogenically-cooled camera"
+    "## Example 1: Cryogenically-cooled camera"
    ]
   },
   {


### PR DESCRIPTION
This is to copy edit the CCD Reduction Guide. The notebooks have been copy edited according to our more relaxed style for guides and tutorials as noted in the Astropy Style Guide, which allows for sentence case headings and contractions.

@mwcraig these were in great shape! I've made some small suggestions you can take or leave as you see fit. One note, in notebook 02-01 the links to the Overscan notebook were not working for me -- are they working for you?