### PR TITLE
Copy editing: CCD Reduction Guide notebooks 05-00 to 05-04

### DIFF
--- a/notebooks/05-00-Flat-corrections.ipynb
+++ b/notebooks/05-00-Flat-corrections.ipynb
@@ -35,23 +35,22 @@
    "source": [
     "## What are flat corrections?\n",
     "\n",
-    "The purpose of flat corrections is to compensate for any non-uniformity in the\n",
+    "The purpose of flat corrections is to compensate for any nonuniformity in the\n",
     "response of the CCD to light. There can be several reasons that the response is\n",
     "not uniform across the detector:\n",
     "\n",
-    "+ variations in the sensitivity of pixels in the detector, though this source is\n",
+    "+ Variations in the sensitivity of pixels in the detector, though this source is\n",
     "usually small.\n",
-    "+ dust on either the filter or the glass window covering the detector.\n",
-    "+ vignetting, a dimming in the corners of the image.\n",
-    "+ anything else in the optical path that affects how much light reaches the\n",
+    "+ Dust on either the filter or the glass window covering the detector.\n",
+    "+ Vignetting, a dimming in the corners of the image.\n",
+    "+ Anything else in the optical path that affects how much light reaches the\n",
     "sensor.\n",
     "\n",
-    "The fix for the non-uniformity is the same in all cases: take an image in which\n",
+    "The fix for nonuniformity is the same in all cases: take an image in which\n",
     "the illumination is uniform and use that to measure the response of the CCD.\n",
     "\n",
     "Unfortunately, achieving uniform illumination is difficult, and uniform\n",
-    "illumination with the same spectrum as the astronomical objects of interest to\n",
-    "you is impossible."
+    "illumination with the same spectrum as the astronomical objects of interest is impossible."
    ]
   },
   {
@@ -93,14 +92,14 @@
     "normalizing (also called rescaling) the calibrated flat frames to a common mean\n",
     "or median before combining them. In both sky and twilight flats the illumination\n",
     "varies naturally from frame-to-frame. If the images are not scaled to a common\n",
-    "value before combining then the ones taken while the sky is brighter will\n",
-    "inappropriately dominate the result. Dome flats ought, in principle, be\n",
+    "value before combining, then the ones taken while the sky is brighter will\n",
+    "inappropriately dominate the result. Dome flats ought to be, in principle,\n",
     "perfectly stable with no time variation in their illumination. In practice,\n",
     "every light source varies at some level; if you are trying to correct 1%\n",
-    "differences in illumination then 1% fluctuations in the light source matter.\n",
+    "differences in illumination, then 1% fluctuations in the light source matter.\n",
     "\n",
     "Typically the mean or median is scaled to 1.0 before combining so that when the\n",
-    "science images are divided by the calibrated, combined flats the science image\n",
+    "science images are divided by the calibrated, combined flats, the science image\n",
     "values do not change too much."
    ]
   }

--- a/notebooks/05-03-Calibrating-the-flats.ipynb
+++ b/notebooks/05-03-Calibrating-the-flats.ipynb
@@ -6,22 +6,22 @@
    "source": [
     "# Calibrating the flats\n",
     "\n",
-    "Recall that the counts in an astronomical image include dark current, noise and\n",
-    "a nearly-constant offset, the bias. The individual flat frames need to have bias\n",
+    "Recall that the counts in an astronomical image include dark current, noise, and\n",
+    "a near-constant offset, the bias. The individual flat frames need to have bias\n",
     "and dark removed from them. Depending on the exposure times of the images you\n",
     "have, you may or may not need to subtract dark and bias separately.\n",
     "\n",
-    "If the combined dark frame needs to be scaled to a different exposure time then\n",
+    "If the combined dark frame needs to be scaled to a different exposure time, then\n",
     "bias and dark must be handled separately; otherwise, the dark and bias can be\n",
     "removed in a single step because dark frames also include bias.\n",
     "\n",
     "The potential reduction steps for flat frames are below:\n",
     "\n",
-    "+ Subtract overscan and trim, if necessary\n",
-    "+ Subtract bias, if necessary\n",
-    "+ Subtract dark current, scaling if necessary (scale down when possible)\n",
+    "+ Subtract overscan and trim, if necessary.\n",
+    "+ Subtract bias, if necessary.\n",
+    "+ Subtract dark current, scaling if necessary (scale down when possible).\n",
     "\n",
-    "As in the chapters about bias and dark we will work through two example. In\n",
+    "As in the chapters about bias and dark we will work through two examples. In\n",
     "Example 1 the darks are not scaled and the overscan region is used as part of\n",
     "the calibration. In Example 2 the darks are scaled and the overscan region is\n",
     "trimmed off without being used."
@@ -117,7 +117,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 1: no scaling of dark frames\n",
+    "## Example 1: No scaling of dark frames\n",
     "\n",
     "The images for this example are from chip 0 of the Large Format Camera at\n",
     "Palomar Observatory. The raw images are at XXX, and this notebook assumes that\n",
@@ -125,7 +125,7 @@
     "called `example1-reduced` in the same folder as this notebook.\n",
     "\n",
     "We'll go through this example twice: once with a single image to explain each\n",
-    "step, then processing all of the flat frames in the directory of raw data.\n",
+    "step, and then again to process all of the flat frames in the directory of raw data.\n",
     "\n",
     "An image collection is defined below, along with a couple of settings useful for\n",
     "this example."
@@ -150,7 +150,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The raw data should be in the directory `example-cryo-LFC`"
+    "The raw data should be in the directory `example-cryo-LFC`."
    ]
   },
   {
@@ -215,8 +215,8 @@
    "metadata": {},
    "source": [
     "There is not a lot of variation in this. Note that the overscan region on the\n",
-    "right stands out as a black bar, and that there is apparently also an overscan\n",
-    "region across the top of the chip. There appears to be a slight variaion in\n",
+    "right stands out as a black bar, and there is apparently also an overscan\n",
+    "region across the top of the chip. There appears to be a slight variation in\n",
     "pixel values from the bottom to the top of the image."
    ]
   },
@@ -254,8 +254,8 @@
    "metadata": {},
    "source": [
     "Trimming off the overscan makes such a big difference primarily because the\n",
-    "image stretch changed; the lowest pixel values are now around 18000 instead of\n",
-    "2000. With that change the non-uniformity across the detector is much clearer."
+    "image stretch changed; the lowest pixel values are now around 18000 instead of \n",
+    "2000. With that change, the nonuniformity across the detector is much clearer."
    ]
   },
   {
@@ -264,7 +264,7 @@
    "source": [
     "### Subtracting bias is not necessary in this example\n",
     "\n",
-    "For this particular set of images there are darks with exposure time 7, 70 and\n",
+    "For this particular set of images there are darks with exposure time 7, 70, and\n",
     "300 sec. The flat images have the exposure times listed below:"
    ]
   },
@@ -293,7 +293,7 @@
     "### Subtract dark current, no scaling necessary in this example\n",
     "\n",
     "We need to subtract the dark without scaling it. Rather than manually figuring\n",
-    "out which dark to subtract we use the dark frame closest in exposure time to the\n",
+    "out which dark to subtract, we use the dark frame closest in exposure time to the\n",
     "flat, within a tolerance of 1 second to ensure that we do not end up using a\n",
     "dark *too* far off in exposure time from the flat.\n",
     "\n",
@@ -357,7 +357,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Calibrated all of the flats in the folder"
+    "### Calibrate all of the flats in the folder"
    ]
   },
   {
@@ -403,11 +403,11 @@
     "## Example 2: Dark frames are scaled\n",
     "\n",
     "The images in this example, like in the previous notebooks, is a\n",
-    "thermo-electrically cooled CCD described in more detail in the\n",
+    "thermoelectrically-cooled CCD described in more detail in the\n",
     "[overscan notebook](01-08-Overscan.ipynb#Case-2:-Thermo-electrically-cooled-Apogee-Aspen-CG16M).\n",
     "\n",
     "We'll go through this example twice: once with a single image to explain each\n",
-    "step, then processing all of the flat frames in the directory of raw data.\n",
+    "step, and then again to process all of the flat frames in the directory of raw data.\n",
     "\n",
     "An image collection is defined below, along with a couple of settings useful for\n",
     "this example."
@@ -432,7 +432,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The raw data should be in the directory `example-thermo-electric`"
+    "The raw data should be in the directory `example-thermo-electric`."
    ]
   },
   {
@@ -562,11 +562,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These are quite different than the exposure time of the dark frames so the dark\n",
+    "These are quite different than the exposure time of the dark frames, so the dark\n",
     "will need to be scaled by exposure time, which means that the bias has been\n",
     "removed from the combined dark.\n",
     "\n",
-    "Because of that, the bias needs to be removed the flat before subtracting the\n",
+    "Because of that, the bias needs to be removed from the flat before subtracting the\n",
     "dark."
    ]
   },
@@ -667,7 +667,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Calibrated all of the flats in the folder"
+    "### Calibrate all of the flats in the folder"
    ]
   },
   {

--- a/notebooks/05-04-Combining-flats.ipynb
+++ b/notebooks/05-04-Combining-flats.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Combining flats\n",
     "\n",
-    "There is one step in combining flats that is different than for most other image\n",
+    "There is one step in combining flats that is different from most other image\n",
     "combination: the flats should be scaled to a common value before combining them.\n",
     "This is particularly important if the flats are twilight flats in which the\n",
     "average image value typically changes significantly as the images are being\n",
@@ -92,7 +92,7 @@
    "metadata": {},
    "source": [
     "These flats are dome flats, essentially pictures of a screen in the dome\n",
-    "illuminated by a light source, so one would not expect there to be much variable\n",
+    "illuminated by a light source, so you would not expect there to be much variable\n",
     "in the typical pixel value between different exposures. There is typically\n",
     "*some* variation, though, so we graph it below."
    ]
@@ -127,7 +127,7 @@
     "Typically it is better to use the median because extreme values do not affect\n",
     "the median as much as the mean.\n",
     "\n",
-    "To scale the frames so that they have the same median value we need to define a\n",
+    "To scale the frames so that they have the same median value, we need to define a\n",
     "function that can calculate the inverse of the median given the data."
    ]
   },
@@ -200,7 +200,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That looks good. Two two flats are displayed below."
+    "That looks good. The two flats are displayed below."
    ]
   },
   {
@@ -231,7 +231,7 @@
     "small dark spots are places where the chip wasn't thinned uniformly.\n",
     "\n",
     "Compare this with [Example 2](#Discussion-of-Example-2) below, which shows a flat\n",
-    "taken with a front-side illuminated camera."
+    "taken with a frontside-illuminated camera."
    ]
   },
   {
@@ -240,7 +240,7 @@
    "source": [
     "## Example 2\n",
     "\n",
-    "The data in this example is from a thermo-electrically cooled Andor Aspen CG16M.\n",
+    "The data in this example is from a thermoelectrically-cooled Andor Aspen CG16M.\n",
     "These flats are twilight flats, taken just after sunset."
    ]
   },
@@ -271,7 +271,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Twilight flats typically differ more from frame-to-frame than dome flats, as\n",
+    "Twilight flats typically differ more frame-to-frame than dome flats, as\n",
     "shown in the figure below."
    ]
   },
@@ -364,8 +364,8 @@
    "metadata": {},
    "source": [
     "This flat looks very different than the one in [Example 1](#Discussion-of-Example-1)\n",
-    "because this CCD is front-side illuminated and the previous one is back-side\n",
-    "illuminated. That means the sensor is on the top of the chip and the light does\n",
+    "because this CCD is frontside-illuminated and the previous one is backside-illuminated. \n",
+    "That means the sensor is on the top of the chip and the light does\n",
     "not pass through the sensor chip itself to reach the sensors. Though only one\n",
     "filter is shown here, the flat field looks slightly different through other\n",
     "filters on this camera."


### PR DESCRIPTION
This is to copy edit the CCD Reduction Guide. The notebooks have been copy edited according to our more relaxed style for guides and tutorials as noted in the Astropy Style Guide, which allows for sentence case headings and contractions.

@mwcraig one quick thing I noticed in these:

Notebook 05-03 seems to be missing a link under “Example 1: No scaling of dark frames” (The raw images are at XXX).