### PR TITLE
Copy editing: CCD Reduction Guide notebooks 06-00 to 07-03

### DIFF
--- a/notebooks/06-00-Reducing-science-images.ipynb
+++ b/notebooks/06-00-Reducing-science-images.ipynb
@@ -47,7 +47,7 @@
     "`subtract_dark`, and `flat_correct`.\n",
     "+ Use the [`ccd_process` function]() to perform all of the reduction steps.\n",
     "\n",
-    "This notebook will do each of those in separate sections below."
+    "This notebook will do each of these in separate sections below."
    ]
   },
   {
@@ -175,9 +175,9 @@
     "current and there is a flat field image for each of the two filters present in\n",
     "the data.\n",
     "\n",
-    "Though we could hard code which dark to use, it is straightforward to set up a\n",
-    "dictionary for accessing the darks, and a separate for accessing the science\n",
-    "images. The goal is to write code that  is more easily reused."
+    "Though we could hard code which dark to use, it is possible to set up a\n",
+    "dictionary for accessing the darks, with a separate one for accessing the science\n",
+    "images. The goal is to write code that is more conveniently reused."
    ]
   },
   {
@@ -196,10 +196,10 @@
    "source": [
     "The calibration steps for each of these science images are:\n",
     "\n",
-    "+ Subtract the overscan from the science image\n",
-    "+ Trim the overscan\n",
-    "+ Subtract the dark current (which in this case also includes the bias)\n",
-    "+ Flat correct the image\n",
+    "+ Subtract the overscan from the science image.\n",
+    "+ Trim the overscan.\n",
+    "+ Subtract the dark current (which in this case also includes the bias).\n",
+    "+ Flat correct the image.\n",
     "\n",
     "These are the minimum steps needed to calibrate. Gain correcting the data and\n",
     "identifying cosmic rays are additional steps that might often be done at this\n",
@@ -285,7 +285,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The camera in this example is a thermo-electrically cooled Andor Aspen CG16M. In\n",
+    "The camera in this example is a thermoelectrically-cooled Andor Aspen CG16M. In\n",
     "previous notebooks we decided that:\n",
     "\n",
     "+ The overscan region of this camera is not useful.\n",
@@ -355,7 +355,7 @@
    "metadata": {},
    "source": [
     "Although there is only one of each type of combined calibration image, the code\n",
-    "below sets up a dictionary for the flats and darks. That code will work in a\n",
+    "below sets up a dictionary for the flats and darks. That code will work on a\n",
     "more typical night when there might be several filters and multiple exposure\n",
     "times."
    ]
@@ -379,8 +379,8 @@
    "source": [
     "The calibration steps for each of these science images is:\n",
     "\n",
-    "+ Trim the overscan\n",
-    "+ Subtract bias, because bias was subtracted from the dark frames\n",
+    "+ Trim the overscan.\n",
+    "+ Subtract bias, because bias was subtracted from the dark frames.\n",
     "+ Subtract dark, using the dark closest in exposure time to the science image.\n",
     "+ Flat correct the images, using the combined flat whose filter matches the\n",
     "science image."
@@ -435,7 +435,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In both images most of the nonunifomity in the background has been removed along\n",
+    "In both images, most of the nonunifomity in the background has been removed along\n",
     "the bright column and the sensor glow on the left and right edges of the\n",
     "uncalibrated images.\n",
     "\n",

--- a/notebooks/07-00-Combining-images.ipynb
+++ b/notebooks/07-00-Combining-images.ipynb
@@ -7,7 +7,7 @@
     "# Combining images\n",
     "\n",
     "An overview of combining images is in [Image combination](01-06-Image-combination.ipynb). The next\n",
-    "sections discuss a couple of common cases not covered the earlier section:\n",
+    "sections discuss a couple of common cases not covered in the earlier section:\n",
     "\n",
     "+ Combining science images without aligning them to generate *sky flats*. These\n",
     "flats have the advantage that the light source exactly matches the spectrum of\n",


### PR DESCRIPTION
This is to copy edit the CCD Reduction Guide. The notebooks have been copy edited according to our more relaxed style for guides and tutorials as noted in the Astropy Style Guide, which allows for sentence case headings and contractions.

@mwcraig I noticed there wasn't any content in notebooks 07-02 and 07-03 beyond the titles -- are you planning to add content for these?